### PR TITLE
feat: Fuse (mainnet & testnet) spec from Protofire DAO

### DIFF
--- a/mainnet-1/specs/fuse.json
+++ b/mainnet-1/specs/fuse.json
@@ -19,7 +19,7 @@
                 "shares": 1,
                 "min_stake_provider": {
                     "denom": "ulava",
-                    "amount": "47500000000"
+                    "amount": "15000000000"
                 },
                 "api_collections": [
                     {
@@ -63,7 +63,7 @@
                 "shares": 1,
                 "min_stake_provider": {
                     "denom": "ulava",
-                    "amount": "47500000000"
+                    "amount": "15000000000"
                 },
                 "api_collections": [
                     {

--- a/mainnet-1/specs/fuse.json
+++ b/mainnet-1/specs/fuse.json
@@ -42,6 +42,27 @@
                                         "expected_value": "0x7a"
                                     }
                                 ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                    {
+                                        "latest_distance": 17280
+                                    },
+                                    {
+                                        "extension": "archive",
+                                        "expected_value": "0x0"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 17000
+                                }
                             }
                         ]
                     }
@@ -86,6 +107,27 @@
                                         "expected_value": "0x7b"
                                     }
                                 ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                    {
+                                        "latest_distance": 17280
+                                    },
+                                    {
+                                        "extension": "archive",
+                                        "expected_value": "0x0"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 17000
+                                }
                             }
                         ]
                     }

--- a/mainnet-1/specs/fuse.json
+++ b/mainnet-1/specs/fuse.json
@@ -1,0 +1,97 @@
+{
+    "proposal": {
+        "title": "Add Specs: Fuse",
+        "description": "Adding new specification support for relaying Fuse data on Lava",
+        "specs": [
+            {
+                "index": "FUSE",
+                "name": "fuse mainnet",
+                "enabled": true,
+                "imports": [
+                    "ETH1"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 34,
+                "blocks_in_finalization_proof": 0,
+                "average_block_time": 5040,
+                "allowed_block_lag_for_qos_sync": 2,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0x7a"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": "SPARK",
+                "name": "fuse testnet",
+                "enabled": true,
+                "imports": [
+                    "ETH1"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 4,
+                "blocks_in_finalization_proof": 0,
+                "average_block_time": 5000,
+                "allowed_block_lag_for_qos_sync": 2,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0x7b"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "deposit": "10000000ulava"
+}


### PR DESCRIPTION
**Name**: Protofire DAO
**Discord**: `amalyshauprotofiredao`
Commission: 1.5%

```
+1% - Support and run a Provider on testnet;
+0.5% - Updated existing fuse spec.
```

We'd like to get additional % for:

* Benchmarking CU and timeouts;
* Providing active support to Providers, if more than 20 providers are retained over 3 months.

Why Protofire?

The partnership between Protofire and the Fuse Network is a strategic collaboration that supports and strengthens the Fuse ecosystem. Protofire, a development and blockchain infrastructure company, has become a crucial partner within the Fuse ecosystem, serving both as a technical backbone and as an operational support system. This partnership leverages Protofire's expertise in blockchain infrastructure management, making them instrumental in the maintenance, stability, and overall health of the Fuse Network.

Protofire also plays a pivotal role as the primary validator operator on the Fuse Network. Validators are essential to the blockchain’s consensus mechanism, as they confirm and secure transactions, add new blocks to the blockchain, and help to maintain network integrity. By serving as the main validator, Protofire provides stability and reliability to the Fuse Network’s consensus process.