### PR TITLE
feat: add Filecoin testnet (Calibrationnet) spec from Protofire DAO

### DIFF
--- a/mainnet-1/specs/filecoin-testnet.json
+++ b/mainnet-1/specs/filecoin-testnet.json
@@ -1,0 +1,1900 @@
+{
+        "proposal": {
+            "title": "Add Specs: Filecoin Calibrationnet",
+            "description": "Adding new specification support for relaying Filecoin testnet data on Lava",
+            "specs": [
+                {
+                    "index": "FVMT",
+                    "name": "filecoin testnet",
+                    "enabled": true,
+                    "imports": [
+                        "ETH1"
+                    ],
+                    "reliability_threshold": 268435455,
+                    "data_reliability_enabled": true,
+                    "block_distance_for_finalized_data": 900,
+                    "blocks_in_finalization_proof": 3,
+                    "average_block_time": 30000,
+                    "allowed_block_lag_for_qos_sync": 2,
+                    "shares": 1,
+                    "min_stake_provider": {
+                        "denom": "ulava",
+                        "amount": "5000000000"
+                    },
+                    "api_collections": [
+                        {
+                            "enabled": true,
+                            "collection_data": {
+                                "api_interface": "jsonrpc",
+                                "internal_path": "",
+                                "type": "POST",
+                                "add_on": ""
+                            },
+                            "apis": [
+                                {
+                                    "name": "Filecoin.ChainGetBlock",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetBlockMessages",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetEvents",
+                                    "block_parsing": {},
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetGenesis",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetMessage",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetNode",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetParentMessages",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetParentReceipts",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetPath",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetTipSet",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetTipSetAfterHeight",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "0"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainGetTipSetByHeight",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "0"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainHasObj",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainHead",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainNotify",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.ChainReadObj",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthAccounts",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthAddressToFilecoinAddress",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthBlockNumber",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthCall",
+                                     "block_parsing": {
+                                        "parser_arg": [
+                                            "1"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthChainId",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthEstimateGas",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthFeeHistory",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGasPrice",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetBalance",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "1"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetBlockByHash",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetBlockByNumber",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "0"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetBlockTransactionCountByHash",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetBlockTransactionCountByNumber",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "0"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetCode",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "1"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetFilterChanges",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "1"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetFilterLogs",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetLogs",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "0",
+                                            "toBlock"
+                                        ],
+                                        "parser_func": "PARSE_CANONICAL"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetMessageCidByTransactionHash",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                }, 
+                                {
+                                    "name": "Filecoin.EthGetStorageAt",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "2"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetTransactionByHash",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetTransactionByHashLimited",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetTransactionCount",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "1"
+                                        ],
+                                        "parser_func": "PARSE_BY_ARG"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetTransactionHashByCid",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthGetTransactionReceipt",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthMaxPriorityFeePerGas",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthNewBlockFilter",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            ""
+                                        ],
+                                        "parser_func": "EMPTY"
+                                    },
+                                    "compute_units": 20,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthNewFilter",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "0",
+                                            "toBlock"
+                                        ],
+                                        "parser_func": "PARSE_CANONICAL"
+                                    },
+                                    "compute_units": 20,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthNewPendingTransactionFilter",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 20,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthProtocolVersion",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthSendRawTransaction",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 1,
+                                        "hanging_api": true
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthSubscribe",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 1000,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": true,
+                                        "subscription": true,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthSyncing",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            ""
+                                        ],
+                                        "parser_func": "EMPTY"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthTraceBlock",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": true,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthTraceReplayBlockTransactions",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": true,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthUninstallFilter",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": true,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.EthUnsubscribe",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": true,
+                                        "subscription": true,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.FilecoinAddressToEthAddress",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.GasEstimateGasPremium",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.GasEstimateMessageGas",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.GetActorEventsRaw",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.MinerGetBaseInfo",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.MsigGetAvailableBalance",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.MsigGetPending",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.MsigGetVested",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.MsigGetVestingSchedule",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.NetListening",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.NetVersion",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateAccountKey",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateCall",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateCirculatingSupply",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateDealProviderCollateralBounds",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateDecodeParams",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateGetActor",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateGetAllocation",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateGetAllocationForPendingDeal",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateGetAllocations",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateGetClaim",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateGetClaims",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateListMiners",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateLookupID",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMarketBalance",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMarketParticipants",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMarketStorageDeal",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerAvailableBalance",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerDeadlines",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerFaults",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerInfo",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerPartitions",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerPower",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerProvingDeadline",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerRecoveries",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerSectorCount",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateMinerSectors",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateNetworkName",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateNetworkVersion",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateReadState",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateReplay",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateSearchMsg",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateSectorGetInfo",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateVMCirculatingSupplyInternal",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateVerifiedClientStatus",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateVerifierStatus",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.StateWaitMsg",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.Version",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": false,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.WalletBalance",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                },
+                                {
+                                    "name": "Filecoin.WalletVerify",
+                                    "block_parsing": {
+                                        "parser_arg": [
+                                            "latest"
+                                        ],
+                                        "parser_func": "DEFAULT"
+                                    },
+                                    "compute_units": 10,
+                                    "enabled": true,
+                                    "category": {
+                                        "deterministic": true,
+                                        "local": false,
+                                        "subscription": false,
+                                        "stateful": 0
+                                    },
+                                    "extra_compute_units": 0
+                                }
+                            ],
+                            "headers": [],
+                            "inheritance_apis": [],
+                            "parse_directives": [],
+                            "verifications": [
+                                {
+                                    "name": "chain-id",
+                                    "values": [
+                                        {
+                                            "expected_value": "0x4cb2f"
+                                        }
+                                    ]
+                                },
+                                {
+                                  "name": "pruning",
+                                  "values": [
+                                    {
+                                      "expected_value": ""
+                                    },
+                                    {
+                                      "extension": "archive",
+                                      "expected_value": ""
+                                    }
+                                  ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "deposit": "10000000ulava"
+}

--- a/mainnet-1/specs/filecoin.json
+++ b/mainnet-1/specs/filecoin.json
@@ -1416,24 +1416,6 @@
                                     "extra_compute_units": 0
                                 },
                                 {
-                                    "name": "Filecoin.StateMarketBalance",
-                                    "block_parsing": {
-                                        "parser_arg": [
-                                            "latest"
-                                        ],
-                                        "parser_func": "DEFAULT"
-                                    },
-                                    "compute_units": 10,
-                                    "enabled": true,
-                                    "category": {
-                                        "deterministic": false,
-                                        "local": false,
-                                        "subscription": false,
-                                        "stateful": 0
-                                    },
-                                    "extra_compute_units": 0
-                                },
-                                {
                                     "name": "Filecoin.StateMarketParticipants",
                                     "block_parsing": {
                                         "parser_arg": [


### PR DESCRIPTION
**Name**: Protofire DAO
**Discord**: `dzmitrykliapkou_51649`
**Commission**: 1.5%

```
+1% - Support and run a Provider on testnet
+0,5% - The spec is based on FVM spec
```

We'd like to get additional %% for 
- "benchmarking CU and timeouts" 
- "providing active support to Providers, if more than 20 providers are retained over 3 months"

### Why Protofire?

Our work with the [Glif Nodes](https://lotus.filecoin.io/lotus/developers/glif-nodes/) team exemplifies our capability in providing reliable RPC node services, ensuring that our solutions meet the demands of a growing ecosystem like Filecoin. We have been involved since the pre-Mainnet phase, supporting various network types and contributing significantly to the Filecoin landscape.

Our collaboration with Infinite Scroll to form Glif underscores our commitment to enhancing the Filecoin network. Through Glif, we offer various services, including wallet solutions, multisig functionality, notary services, and node hosting. Our node services provide secure and efficient access to the Filecoin network, which is critical for Lava providers looking to integrate seamlessly into this growing ecosystem.