### PR TITLE
add sonic testnet

### DIFF
--- a/mainnet-1/specs/fantom.json
+++ b/mainnet-1/specs/fantom.json
@@ -974,6 +974,50 @@
                         ]
                     }
                 ]
+            },
+            {
+                "index": "SONICT",
+                "name": "sonic testnet (blaze)",
+                "enabled": true,
+                "imports": [
+                    "FTM250"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 0,
+                "blocks_in_finalization_proof": 1,
+                "average_block_time": 1500,
+                "allowed_block_lag_for_qos_sync": 7,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "5000000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0xdede"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     },

--- a/mainnet-1/specs/fantom.json
+++ b/mainnet-1/specs/fantom.json
@@ -977,7 +977,7 @@
             },
             {
                 "index": "SONICT",
-                "name": "sonic testnet (blaze)",
+                "name": "sonic testnet blaze",
                 "enabled": true,
                 "imports": [
                     "FTM250"


### PR DESCRIPTION
# Lava Network Spec Champion Pull Request

Fantom will soon be deprecated and will be replaced by Sonic.
Sonic mainnet launched today and still no RPC endpoint. In the meantime, added Sonic testnet (called Blaze)

## Personal Information
- Discord Username: 
- Lava Champion Wallet Address: 

## Spec Details
- [ ] This is a spec add
- [ ] This is a spec update

### Network Coverage
- [ ] Mainnet implementation included
- [ ] Testnet implementation included

### Staking Requirements
- Minimum Staking Amount (`min_stake_provider`): 5,000,000,000ulava

### Activity Commission Rate (`contributor_percentage`)
Please check all that apply and provide the total percentage:
- [ ] Running a provider on testnet (up to 1%)
- [ ] Creating new spec from scratch (up to 1%)
- [ ] Inheriting existing specs (0.5% mandatory)
- [ ] Benchmarking CU and timeouts (1%)
- [ ] Supporting 20+ providers for 3 months (1%)
- [ ] Referral-based incentive pools (2-3%)

Total Commission Rate: __%

## Champion Background and Experience
[Describe your experience running nodes]

### Previous Lava Provider Contributions
[Detail your contributions to the Lava Provider community]

## Technical Implementation
### Endpoint Information
- Public Endpoint Used for Testing: 

### Testing Details
[Attach or link to testing logs]

## Technical Review Checklist
- [ ] Average block and spec parameters
- [ ] Chain Id verification
- [ ] Pruning verification (pruned: 24H, archive: 23H40M)
- [ ] Inherited specs verified
- [ ] Spec name confirmed
- [ ] Testing logs reviewed
- [ ] New APIs reviewed

## Additional Notes
[Include any additional information or context that might be relevant]

---
Note: Please ensure all sections are filled out completely before submitting. Incomplete submissions may delay the review process.